### PR TITLE
Bug Fix: When using listParts.py with cutepussycats.xml, part one (P1…

### DIFF
--- a/scripts/listParts.py
+++ b/scripts/listParts.py
@@ -24,7 +24,7 @@ def listParts(root):
             partname = ''
             for c in b.findall('part-name'):
                 partname = c.text
-            print partid, partname
+            print "Part ID:", partid, "  Part Name:", partname
 
 #
 # Parse command line arguments


### PR DESCRIPTION
…) is listed twice. Looking at the raw xml file, there is only one P1.

I've made it more clear that it is printing out the Part ID and the Part Name.
In the case of cutepussycats.xml, both Part ID and Part Name are P1.